### PR TITLE
Use Rails.logger as default when previously set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,22 @@ gem 'grape-middleware-logger'
 class API < Grape::API
   use Grape::Middleware::Logger
 end
-```    
-Using Grape with Rails or want to customize the logging? You can provide a `logger` option, which just has to respond to `.info(msg)`. Example Rails logging and parameter sanitization:
+```
+
+#### Rails
+Using Grape with Rails? `Rails.logger` will be used by default.
+
+#### Custom setup
+Want to customize the logging? You can provide a `logger` option.
+
+Example using a CustomLogger and parameter sanitization:
 ```ruby
-use Grape::Middleware::Logger, { 
-  logger: Rails.logger, 
+use Grape::Middleware::Logger, {
+  logger: CustomLogger.new,
   filter: ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
 }
 ```
+The `logger` option can be any object that responds to `.info(msg)`
 
 The `filter` option can be any object that responds to `.filter(params_hash)`
 

--- a/lib/grape/middleware/logger.rb
+++ b/lib/grape/middleware/logger.rb
@@ -3,79 +3,74 @@ require 'grape'
 
 # avoid superclass mismatch when version file gets loaded first
 Grape::Middleware.send :remove_const, :Logger if defined? Grape::Middleware::Logger
-module Grape
-  module Middleware
-    class Logger < Grape::Middleware::Globals
+class Grape::Middleware::Logger < Grape::Middleware::Globals
+  def before
+    start_time
+    super # sets env['grape.*']
+    logger.info ''
+    logger.info %Q(Started #{env['grape.request'].request_method} "#{env['grape.request'].path}")
+    logger.info %Q(  Parameters: #{parameters})
+  end
 
-      def before
-        start_time
-        super # sets env['grape.*']
-        logger.info ''
-        logger.info %Q(Started #{env['grape.request'].request_method} "#{env['grape.request'].path}")
-        logger.info %Q(  Parameters: #{parameters})
+  # @note Error and exception handling are required for the +after+ hooks
+  #   Exceptions are logged as a 500 status and re-raised
+  #   Other "errors" are caught, logged and re-thrown
+  def call!(env)
+    @env = env
+    before
+    error = catch(:error) do
+      begin
+        @app_response = @app.call(@env)
+      rescue => e
+        after_exception(e)
+        raise e
       end
-
-      # @note Error and exception handling are required for the +after+ hooks
-      #   Exceptions are logged as a 500 status and re-raised
-      #   Other "errors" are caught, logged and re-thrown
-      def call!(env)
-        @env = env
-        before
-        error = catch(:error) do
-          begin
-            @app_response = @app.call(@env)
-          rescue => e
-            after_exception(e)
-            raise e
-          end
-          nil
-        end
-        if error
-          after_failure(error)
-          throw(:error, error)
-        else
-          after(@app_response.status)
-        end
-        @app_response
-      end
-
-      def after(status)
-        logger.info "Completed #{status} in #{((Time.now - start_time) * 1000).round(2)}ms"
-        logger.info ''
-      end
-
-      #
-      # Helpers
-      #
-
-      def after_exception(e)
-        logger.info %Q(  Error: #{e.message})
-        after(500)
-      end
-
-      def after_failure(error)
-        logger.info %Q(  Error: #{error[:message]}) if error[:message]
-        after(error[:status])
-      end
-
-      def parameters
-        request_params = env['grape.request.params'].to_hash
-        request_params.merge!(env['action_dispatch.request.request_parameters'] || {}) # for Rails
-        if @options[:filter]
-          @options[:filter].filter(request_params)
-        else
-          request_params
-        end
-      end
-
-      def start_time
-        @start_time ||= Time.now
-      end
-
-      def logger
-        @logger ||= @options[:logger] || ::Logger.new(STDOUT)
-      end
+      nil
     end
+    if error
+      after_failure(error)
+      throw(:error, error)
+    else
+      after(@app_response.status)
+    end
+    @app_response
+  end
+
+  def after(status)
+    logger.info "Completed #{status} in #{((Time.now - start_time) * 1000).round(2)}ms"
+    logger.info ''
+  end
+
+  #
+  # Helpers
+  #
+
+  def after_exception(e)
+    logger.info %Q(  Error: #{e.message})
+    after(500)
+  end
+
+  def after_failure(error)
+    logger.info %Q(  Error: #{error[:message]}) if error[:message]
+    after(error[:status])
+  end
+
+  def parameters
+    request_params = env['grape.request.params'].to_hash
+    request_params.merge!(env['action_dispatch.request.request_parameters'] || {}) # for Rails
+    if @options[:filter]
+      @options[:filter].filter(request_params)
+    else
+      request_params
+    end
+  end
+
+  def start_time
+    @start_time ||= Time.now
+  end
+
+  def logger
+    @logger ||= @options[:logger] || Logger.new(STDOUT)
   end
 end
 

--- a/lib/grape/middleware/logger.rb
+++ b/lib/grape/middleware/logger.rb
@@ -70,7 +70,8 @@ class Grape::Middleware::Logger < Grape::Middleware::Globals
   end
 
   def logger
-    @logger ||= @options[:logger] || Logger.new(STDOUT)
+    @logger ||= @options[:logger]
+    @logger ||= defined?(Rails) && Rails.logger.present? ? Rails.logger : Logger.new(STDOUT)
   end
 end
 

--- a/spec/lib/grape/middleware/logger_spec.rb
+++ b/spec/lib/grape/middleware/logger_spec.rb
@@ -138,8 +138,7 @@ describe Grape::Middleware::Logger do
   #
   # Test class
   #
-
-  ParamFilter = Class.new do
+  class ParamFilter
     def filter(opts)
       opts.each_pair { |key, val| val[0..-1] = '[FILTERED]' if key == 'password' }
     end

--- a/spec/lib/grape/middleware/logger_spec.rb
+++ b/spec/lib/grape/middleware/logger_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 require 'grape/middleware/logger'
 
+class Rails
+  def self.logger
+    nil
+  end
+end
+
 describe Grape::Middleware::Logger do
   let(:app) { double('app') }
   let(:options) { { filter: ParamFilter.new, logger: Object.new } }
@@ -99,6 +105,13 @@ describe Grape::Middleware::Logger do
 
       it 'defaults to the the standard Logger' do
         expect(subject.logger).to be_a(Logger)
+      end
+
+      it 'defaults to Rails.logger if is set' do
+        rails_logger = double("rails_logger")
+        allow(Rails).to receive(:logger).and_return(rails_logger)
+
+        expect(subject.logger).to eq(rails_logger)
       end
     end
 

--- a/spec/lib/grape/middleware/logger_spec.rb
+++ b/spec/lib/grape/middleware/logger_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 require 'grape/middleware/logger'
 
-class Rails
-  def self.logger
-    nil
-  end
-end
-
 describe Grape::Middleware::Logger do
   let(:app) { double('app') }
   let(:options) { { filter: ParamFilter.new, logger: Object.new } }
@@ -103,15 +97,24 @@ describe Grape::Middleware::Logger do
     context 'when @options[:logger] is nil' do
       let(:options) { {} }
 
-      it 'defaults to the the standard Logger' do
-        expect(subject.logger).to be_a(Logger)
-      end
+      context 'when Rails is defined' do
+        module Rails
+          class << self
+            attr_accessor :logger
+          end
+        end
 
-      it 'defaults to Rails.logger if is set' do
-        rails_logger = double("rails_logger")
-        allow(Rails).to receive(:logger).and_return(rails_logger)
+        it 'defaults to the the standard Logger' do
+          expect(subject.logger).to be_a(Logger)
+        end
 
-        expect(subject.logger).to eq(rails_logger)
+        context 'when Rails.logger is defined' do
+          before { Rails.logger = double('rails_logger') }
+
+          it 'sets @logger to Rails.logger' do
+            expect(subject.logger).to be Rails.logger
+          end
+        end
       end
     end
 


### PR DESCRIPTION
When using Grape + Middleware + Rails it will use Rails.logger by default unless isn't present or if there is a `options[:logger]` present.

I had to change the default namespace hierarchical structure in order to make more suitable to check Rails presence, because otherwise I would have to specify every outside unknown constant with `::`. 

Either way it is not cool to have nesting contexts.

 