### PR TITLE
Add request headers to logger

### DIFF
--- a/lib/grape/middleware/logger.rb
+++ b/lib/grape/middleware/logger.rb
@@ -33,6 +33,7 @@ class Grape::Middleware::Logger < Grape::Middleware::Globals
       start_time.to_s
     ]
     logger.info %Q(Processing by #{processed_by})
+    logger.info %Q(     Headers: #{headers})
     logger.info %Q(  Parameters: #{parameters})
   end
 
@@ -78,6 +79,10 @@ class Grape::Middleware::Logger < Grape::Middleware::Globals
   def after_failure(error)
     logger.info %Q(  Error: #{error[:message]}) if error[:message]
     after(error[:status])
+  end
+
+  def headers
+    env['grape.request.headers']
   end
 
   def parameters

--- a/spec/integration/lib/grape/middleware/logger_spec.rb
+++ b/spec/integration/lib/grape/middleware/logger_spec.rb
@@ -15,6 +15,7 @@ describe Grape::Middleware::Logger, type: :integration do
     expect(subject.logger).to receive(:info).with ''
     expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time})
     expect(subject.logger).to receive(:info).with %Q(Processing by TestAPI/users)
+    expect(subject.logger).to receive(:info).with %Q(     Headers: {})
     expect(subject.logger).to receive(:info).with %Q(  Parameters: {"id"=>"101001", "secret"=>"[FILTERED]", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
     expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
     expect(subject.logger).to receive(:info).with ''

--- a/spec/integration_rails/lib/grape/middleware/logger_spec.rb
+++ b/spec/integration_rails/lib/grape/middleware/logger_spec.rb
@@ -46,6 +46,7 @@ describe Grape::Middleware::Logger, type: :rails_integration do
     expect(subject.logger).to receive(:info).with ''
     expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time})
     expect(subject.logger).to receive(:info).with %Q(Processing by TestAPI/users)
+    expect(subject.logger).to receive(:info).with %Q(     Headers: {})
     expect(subject.logger).to receive(:info).with %Q(  Parameters: {"id"=>"101001", "secret"=>"key", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
     expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
     expect(subject.logger).to receive(:info).with ''


### PR DESCRIPTION
This will adds headers to the log output. 

I don't believe I have the Rails headers included in this. Any suggestions on how to add these? 

NB: Current, failing specs where failing before I started my changes. 
