### PR TITLE
Log exceptions class name

### DIFF
--- a/lib/grape/middleware/logger.rb
+++ b/lib/grape/middleware/logger.rb
@@ -71,7 +71,7 @@ class Grape::Middleware::Logger < Grape::Middleware::Globals
   #
 
   def after_exception(e)
-    logger.info %Q(  Error: #{e.message})
+    logger.info %Q(  #{e.class.name}: #{e.message})
     after(500)
   end
 


### PR DESCRIPTION
Hi. I think that we must write exception class to the log for better analysis (and corresponding tools).

This PR adds this small feature.