### PR TITLE
Log the actual status code of the response

### DIFF
--- a/lib/grape/middleware/logger/rack_head_override.rb
+++ b/lib/grape/middleware/logger/rack_head_override.rb
@@ -1,0 +1,17 @@
+require 'rack/head'
+
+class Grape::Middleware::Logger
+  module RackHeadOverride
+    def call(env)
+      start_time = Time.now
+      response = super
+      if env && env['grape.middleware.logger.text']
+        env['grape.middleware.logger.text'] << "Completed #{response[0]} in #{((Time.now - start_time) * 1000).round(2)}ms\n"
+        env['grape.middleware.logger'].info env.delete('grape.middleware.logger.text')
+      end
+      response
+    end
+  end
+end
+
+Rack::Head.prepend Grape::Middleware::Logger::RackHeadOverride


### PR DESCRIPTION
This approach duck punches the `Rack::Head` middleware to log the status code of the response. This is the first middleware in the Grape stack. The patching risk is deemed low because of the likely hood of change; it implements the established interface for `#call`.

Summary of how it works now:

1. The logger class adds the logging info to a string object
2. The string object and the given logger (or default) are passed along in the `env` hash
3. The override to `Rack::Head#call` uses the logger to finish the request message with the finished response