### PR TITLE
adding an option to format log message to be one line

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,5 @@
+exit
+c
+log_statements.compact.delete_if(&:empty?).each(&:strip!)
+log_statements.compact.delete_if(&:empty?).each(&:lstrip)
+log_statements.compact.delete_if(&:empty?).each(&:strip)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Completed 422 in 6.29ms
 The middleware logger can be customized with the following options:
 
 * The `:logger` option can be any object that responds to `.info(String)`
+* The `:one_line` option configures the log output to be on one line instead of multiple.  It accepts `true` or `false`.   The default configuration is `false`
 * The `:filter` option can be any object that responds to `.filter(Hash)` and returns a hash.
 * The `:headers` option can be either `:all` or array of strings.
     + If `:all`, all request headers will be output.
@@ -62,17 +63,19 @@ For example:
 ```ruby
 insert_after Grape::Middleware::Formatter, Grape::Middleware::Logger, {
   logger: Logger.new(STDERR),
+  one_line: true,
   filter: Class.new { def filter(opts) opts.reject { |k, _| k.to_s == 'password' } end }.new,
   headers: %w(version cache-control)
+  filter: Class.new { def filter(opts) opts.reject { |k, _| k.to_s == 'password' } end }.new
 }
 ```
 
 ## Using Rails?
-`Rails.logger` and `Rails.application.config.filter_parameters` will be used automatically as the default logger and 
+`Rails.logger` and `Rails.application.config.filter_parameters` will be used automatically as the default logger and
 param filterer, respectively. This behavior can be overridden by passing the `:logger` or
 `:filter` option when mounting.
 
-You may want to disable Rails logging for API endpoints, so that the logging doesn't double-up. You can achieve this 
+You may want to disable Rails logging for API endpoints, so that the logging doesn't double-up. You can achieve this
 by switching around some middleware. For example:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Completed 422 in 6.29ms
 The middleware logger can be customized with the following options:
 
 * The `:logger` option can be any object that responds to `.info(String)`
-* The `:one_line` option configures the log output to be on one line instead of multiple.  It accepts `true` or `false`.   The default configuration is `false`
+* The `:condensed` option configures the log output to be on one line instead of multiple.  It accepts `true` or `false`.   The default configuration is `false`
 * The `:filter` option can be any object that responds to `.filter(Hash)` and returns a hash.
 * The `:headers` option can be either `:all` or array of strings.
     + If `:all`, all request headers will be output.
@@ -63,10 +63,9 @@ For example:
 ```ruby
 insert_after Grape::Middleware::Formatter, Grape::Middleware::Logger, {
   logger: Logger.new(STDERR),
-  one_line: true,
+  condensed: true,
   filter: Class.new { def filter(opts) opts.reject { |k, _| k.to_s == 'password' } end }.new,
   headers: %w(version cache-control)
-  filter: Class.new { def filter(opts) opts.reject { |k, _| k.to_s == 'password' } end }.new
 }
 ```
 

--- a/spec/integration/lib/grape/middleware/logger_spec.rb
+++ b/spec/integration/lib/grape/middleware/logger_spec.rb
@@ -11,14 +11,28 @@ describe Grape::Middleware::Logger, type: :integration do
   let(:grape_endpoint) { build(:grape_endpoint) }
   let(:env) { build(:expected_env, grape_endpoint: grape_endpoint) }
 
-  it 'logs all parts of the request' do
-    expect(subject.logger).to receive(:info).with ''
-    expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time})
-    expect(subject.logger).to receive(:info).with %Q(Processing by TestAPI/users)
-    expect(subject.logger).to receive(:info).with %Q(  Parameters: {"id"=>"101001", "secret"=>"[FILTERED]", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
-    expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
-    expect(subject.logger).to receive(:info).with ''
-    subject.call!(env)
+  context 'when the option[:one_line] is false' do
+    let(:options) { { filter: build(:param_filter), logger: Logger.new(Tempfile.new('logger')), one_line: false } }
+
+    it 'logs all parts of the request on multiple lines' do
+      expect(subject.logger).to receive(:info).with ''
+      expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time})
+      expect(subject.logger).to receive(:info).with %Q(Processing by TestAPI/users)
+      expect(subject.logger).to receive(:info).with %Q(  Parameters: {"id"=>"101001", "secret"=>"[FILTERED]", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
+      expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
+      expect(subject.logger).to receive(:info).with ''
+      subject.call!(env)
+    end
+  end
+
+  context 'when the options[:one_line is true' do
+    let(:options) { { filter: build(:param_filter), logger: Logger.new(Tempfile.new('logger')), one_line: true } }
+
+    it 'logs all parts of the request on one line' do
+      expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time} - Processing by TestAPI/users - Parameters: {"id"=>"101001", "secret"=>"[FILTERED]", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
+      expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
+      subject.call!(env)
+    end
   end
 
   context 'when an exception occurs' do

--- a/spec/integration/lib/grape/middleware/logger_spec.rb
+++ b/spec/integration/lib/grape/middleware/logger_spec.rb
@@ -11,8 +11,8 @@ describe Grape::Middleware::Logger, type: :integration do
   let(:grape_endpoint) { build(:grape_endpoint) }
   let(:env) { build(:expected_env, grape_endpoint: grape_endpoint) }
 
-  context 'when the option[:one_line] is false' do
-    let(:options) { { filter: build(:param_filter), logger: Logger.new(Tempfile.new('logger')), one_line: false } }
+  context 'when the option[:condensed] is false' do
+    let(:options) { { filter: build(:param_filter), logger: Logger.new(Tempfile.new('logger')), condensed: false } }
 
     it 'logs all parts of the request on multiple lines' do
       expect(subject.logger).to receive(:info).with ''
@@ -25,8 +25,8 @@ describe Grape::Middleware::Logger, type: :integration do
     end
   end
 
-  context 'when the options[:one_line is true' do
-    let(:options) { { filter: build(:param_filter), logger: Logger.new(Tempfile.new('logger')), one_line: true } }
+  context 'when the options[:condensed is true' do
+    let(:options) { { filter: build(:param_filter), logger: Logger.new(Tempfile.new('logger')), condensed: true } }
 
     it 'logs all parts of the request on one line' do
       expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time} - Processing by TestAPI/users - Parameters: {"id"=>"101001", "secret"=>"[FILTERED]", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})

--- a/spec/integration_rails/lib/grape/middleware/logger_spec.rb
+++ b/spec/integration_rails/lib/grape/middleware/logger_spec.rb
@@ -42,8 +42,8 @@ describe Grape::Middleware::Logger, type: :rails_integration do
     end
   end
 
-  context 'when the option[:one_line] is false' do
-    let(:options) { { one_line: false } }
+  context 'when the option[:condensed] is false' do
+    let(:options) { { condensed: false } }
 
     it 'logs all parts of the request on multiple lines' do
       expect(subject.logger).to receive(:info).with ''
@@ -56,8 +56,8 @@ describe Grape::Middleware::Logger, type: :rails_integration do
     end
   end
 
-  context 'when the option[:one_line] is true' do
-    let(:options) { { one_line: true } }
+  context 'when the option[:condensed] is true' do
+    let(:options) { { condensed: true } }
     it 'logs all parts of the request on one line' do
       expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time} - Processing by TestAPI/users - Parameters: {"id"=>"101001", "secret"=>"key", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
       expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/

--- a/spec/integration_rails/lib/grape/middleware/logger_spec.rb
+++ b/spec/integration_rails/lib/grape/middleware/logger_spec.rb
@@ -42,14 +42,27 @@ describe Grape::Middleware::Logger, type: :rails_integration do
     end
   end
 
-  it 'logs all parts of the request' do
-    expect(subject.logger).to receive(:info).with ''
-    expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time})
-    expect(subject.logger).to receive(:info).with %Q(Processing by TestAPI/users)
-    expect(subject.logger).to receive(:info).with %Q(  Parameters: {"id"=>"101001", "secret"=>"key", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
-    expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
-    expect(subject.logger).to receive(:info).with ''
-    subject.call!(env)
+  context 'when the option[:one_line] is false' do
+    let(:options) { { one_line: false } }
+
+    it 'logs all parts of the request on multiple lines' do
+      expect(subject.logger).to receive(:info).with ''
+      expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time})
+      expect(subject.logger).to receive(:info).with %Q(Processing by TestAPI/users)
+      expect(subject.logger).to receive(:info).with %Q(  Parameters: {"id"=>"101001", "secret"=>"key", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
+      expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
+      expect(subject.logger).to receive(:info).with ''
+      subject.call!(env)
+    end
+  end
+
+  context 'when the option[:one_line] is true' do
+    let(:options) { { one_line: true } }
+    it 'logs all parts of the request on one line' do
+      expect(subject.logger).to receive(:info).with %Q(Started POST "/api/1.0/users" at #{subject.start_time} - Processing by TestAPI/users - Parameters: {"id"=>"101001", "secret"=>"key", "customer"=>[], "name"=>"foo", "password"=>"[FILTERED]"})
+      expect(subject.logger).to receive(:info).with /Completed 200 in \d+.\d+ms/
+      subject.call!(env)
+    end
   end
 
   describe 'the "processing by" section' do


### PR DESCRIPTION
I'm using this to make searching logs easier.    When filtering on a keyword the current multi-line log format makes it more difficult to get to all the information that is being logged.

This will add a configuration to the logger to format all the same information into one log line before processing the request and after processing the request.