### PR TITLE
Add "require" to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ gem 'grape-middleware-logger'
 
 ## Usage
 ```ruby
+require 'grape'
+require 'grape/middleware/logger'
+
 class API < Grape::API
   # @note Make sure this is above your first +mount+
   insert_after Grape::Middleware::Formatter, Grape::Middleware::Logger


### PR DESCRIPTION
It's not obvious that one must require `grape/middleware/logger` and not `grape-middleware-logger`