### PR TITLE
Use ActiveSupport::ParameterFilter instead of ActionDispatch::Http::ParameterFilter in Rails 6 and above

### DIFF
--- a/lib/grape/middleware/logger/railtie.rb
+++ b/lib/grape/middleware/logger/railtie.rb
@@ -2,6 +2,11 @@ class Grape::Middleware::Logger::Railtie < Rails::Railtie
   options = Rails::VERSION::MAJOR < 5 ? { after: :load_config_initializers } : {}
   initializer 'grape.middleware.logger', options do
     Grape::Middleware::Logger.logger = Rails.application.config.logger || Rails.logger.presence
-    Grape::Middleware::Logger.filter = ActionDispatch::Http::ParameterFilter.new Rails.application.config.filter_parameters
+    parameter_filter_class = if Rails::VERSION::MAJOR >= 6
+                               ActiveSupport::ParameterFilter
+                             else
+                               ActionDispatch::Http::ParameterFilter
+                             end
+    Grape::Middleware::Logger.filter = parameter_filter_class.new Rails.application.config.filter_parameters
   end
 end


### PR DESCRIPTION
This addresses a change in Rails 6: https://github.com/rails/rails/pull/34039