### PR TITLE
Fix compatibility with Grape 2.1

### DIFF
--- a/lib/grape/middleware/logger.rb
+++ b/lib/grape/middleware/logger.rb
@@ -93,7 +93,7 @@ class Grape::Middleware::Logger < Grape::Middleware::Globals
 
   def parameters
     request_params = env[Grape::Env::GRAPE_REQUEST_PARAMS].to_hash
-    request_params.merge! env[Grape::Env::RACK_REQUEST_FORM_HASH] if env[Grape::Env::RACK_REQUEST_FORM_HASH]
+    request_params.merge! env[Rack::RACK_REQUEST_FORM_HASH] if env[Rack::RACK_REQUEST_FORM_HASH]
     request_params.merge! env['action_dispatch.request.request_parameters'] if env['action_dispatch.request.request_parameters']
     if @options[:filter]
       @options[:filter].filter(request_params)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -45,7 +45,7 @@ FactoryGirl.define do
         Grape::Env::GRAPE_REQUEST => grape_request,
         Grape::Env::GRAPE_REQUEST_PARAMS => params,
         Grape::Env::GRAPE_REQUEST_HEADERS => headers,
-        Grape::Env::RACK_REQUEST_FORM_HASH => post_params,
+        Rack::RACK_REQUEST_FORM_HASH => post_params,
         Grape::Env::API_ENDPOINT => grape_endpoint
       ).merge(other_env_params)
     end


### PR DESCRIPTION
this replaces a removed constant from Grape with the same constant Grape is now using. Since this constant is part of Rack itself it should be compatible with older versions as well.

Fixes #27